### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4,7 +4,7 @@ A LaTeX document class to insert initials at the beginning of every paragraph to
 
 # Purpose
 
-This package should help you (and in the first place, me) to typeset beatiful books in the style of the old incunabula. The main features are: Multicolored initials at every paragraph and thin lines under each line (as in old handwritings and incunabula).
+This package should help you (and in the first place, me) to typeset beautiful books in the style of the old incunabula. The main features are: Multicolored initials at every paragraph and thin lines under each line (as in old handwritings and incunabula).
 
 frunge-lettrine is a wrapper for the great package lettrine by Daniel Flipo. The main purpose is the /automatic/ insertion of an /multicolored/ initial at every paragraph. Last (but not least!) it inserts thin lines.
 


### PR DESCRIPTION
@alt, I've corrected a typographical error in the documentation of the [frunge-lettrine](https://github.com/alt/frunge-lettrine) project. Specifically, I've changed beatiful to beautiful. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
